### PR TITLE
Audit: Performance Fee WP-I1

### DIFF
--- a/contracts/interfaces/ILiquidityPoolManager.sol
+++ b/contracts/interfaces/ILiquidityPoolManager.sol
@@ -32,13 +32,5 @@ interface ILiquidityPoolManager {
         uint128 liquidity
     ) external returns (uint256 amount0, uint256 amount1);
 
-    function collect(int24 lowerTick, int24 upperTick) external returns (uint128 amount0, uint128 amount1);
-
-    function burn(
-        int24 lowerTick,
-        int24 upperTick,
-        uint128 liquidity
-    ) external returns (uint256 amount0, uint256 amount1);
-
     function burnAndCollect(int24 _lowerTick, int24 _upperTick, uint128 _liquidity) external returns (uint256, uint256);
 }

--- a/contracts/poolManager/CamelotV3LiquidityPoolManager.sol
+++ b/contracts/poolManager/CamelotV3LiquidityPoolManager.sol
@@ -1,21 +1,23 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.16;
 
-import {ILiquidityPoolManager} from "../interfaces/ILiquidityPoolManager.sol";
-import {IAlgebraPool} from "../vendor/algebra/IAlgebraPool.sol";
-import {IAlgebraMintCallback} from "../vendor/algebra/callback/IAlgebraMintCallback.sol";
 import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-
-//libraries
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
-import {TickMath} from "../libs/uniswap/TickMath.sol";
-import {FullMath, LiquidityAmounts} from "../libs/uniswap/LiquidityAmounts.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+import {ILiquidityPoolManager} from "@src/interfaces/ILiquidityPoolManager.sol";
+import {ILiquidityPoolCollectable, PerformanceFee} from "@src/poolManager/libs/PerformanceFee.sol";
+import {IAlgebraPool} from "@src/vendor/algebra/IAlgebraPool.sol";
+import {IAlgebraMintCallback} from "@src/vendor/algebra/callback/IAlgebraMintCallback.sol";
+import {TickMath} from "@src/libs/uniswap/TickMath.sol";
+import {FullMath, LiquidityAmounts} from "@src/libs/uniswap/LiquidityAmounts.sol";
 
 // import "forge-std/console2.sol";
 
-contract CamelotV3LiquidityPoolManager is ILiquidityPoolManager, IAlgebraMintCallback {
+contract CamelotV3LiquidityPoolManager is Ownable, ILiquidityPoolManager, IAlgebraMintCallback {
     using SafeERC20 for IERC20;
     using TickMath for int24;
+    using PerformanceFee for ILiquidityPoolCollectable;
 
     /* ========== Structs ========== */
 
@@ -28,6 +30,8 @@ contract CamelotV3LiquidityPoolManager is ILiquidityPoolManager, IAlgebraMintCal
     IAlgebraPool public pool;
     bool public immutable reversed; //if baseToken > targetToken of Vault, true
     address public vault;
+    address perfFeeRecipient;
+    uint128 public perfFeeDivisor = 10; // 10% of profit
 
     /* ========== MODIFIER ========== */
     modifier onlyVault() {
@@ -199,6 +203,19 @@ contract CamelotV3LiquidityPoolManager is ILiquidityPoolManager, IAlgebraMintCal
 
     /* ========== WRITE FUNCTIONS ========== */
 
+    function setPerfFeeRecipient(address _perfFeeRecipient) external onlyOwner {
+        perfFeeRecipient = _perfFeeRecipient;
+    }
+
+    /**
+     * @dev set performance fee divisor
+     * @param _perfFeeDivisor divisor of performance fee. setting 0 will disable performance fee
+     */
+
+    function setPerfFeeDivisor(uint128 _perfFeeDivisor) external onlyOwner {
+        perfFeeDivisor = _perfFeeDivisor;
+    }
+
     function mint(int24 lowerTick, int24 upperTick, uint128 liquidity) external onlyVault returns (uint256, uint256) {
         bytes memory data = abi.encode(msg.sender);
 
@@ -213,27 +230,19 @@ contract CamelotV3LiquidityPoolManager is ILiquidityPoolManager, IAlgebraMintCal
         return reversed ? (amount1, amount0) : (amount0, amount1);
     }
 
-    function collect(int24 lowerTick, int24 upperTick) external onlyVault returns (uint128, uint128) {
-        (uint128 _amount0, uint128 _amount1) = pool.collect(
-            msg.sender,
-            lowerTick,
-            upperTick,
-            type(uint128).max,
-            type(uint128).max
-        );
-        return reversed ? (_amount1, _amount0) : (_amount0, _amount1);
-    }
-
-    function burn(int24 lowerTick, int24 upperTick, uint128 liquidity) external onlyVault returns (uint256, uint256) {
-        (uint256 _burn0, uint256 _burn1) = pool.burn(lowerTick, upperTick, liquidity);
-        return reversed ? (_burn1, _burn0) : (_burn0, _burn1);
-    }
-
     function burnAndCollect(
         int24 lowerTick,
         int24 upperTick,
         uint128 liquidity
     ) external onlyVault returns (uint256, uint256) {
+        PerformanceFee.FeeCollectParams memory _params = PerformanceFee.FeeCollectParams({
+            lowerTick: lowerTick,
+            upperTick: upperTick,
+            perfFeeRecipient: perfFeeRecipient,
+            perfFeeDivisor: perfFeeDivisor
+        });
+        ILiquidityPoolCollectable(address(pool)).takeFee(_params);
+
         uint256 _burn0;
         uint256 _burn1;
         if (liquidity > 0) {

--- a/contracts/poolManager/UniswapV3LiquidityPoolManager.sol
+++ b/contracts/poolManager/UniswapV3LiquidityPoolManager.sol
@@ -11,7 +11,6 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 //libraries
 import {ErrorsV1} from "../coreV1/ErrorsV1.sol";
-import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {TickMath} from "../libs/uniswap/TickMath.sol";
 import {FullMath, LiquidityAmounts} from "../libs/uniswap/LiquidityAmounts.sol";
 
@@ -208,23 +207,6 @@ contract UniswapV3LiquidityPoolManager is Ownable, ILiquidityPoolManager, IUnisw
 
         (uint256 amount0, uint256 amount1) = pool.mint(address(this), lowerTick, upperTick, liquidity, data);
         return reversed ? (amount1, amount0) : (amount0, amount1);
-    }
-
-    function collect(int24 lowerTick, int24 upperTick) external onlyVault returns (uint128, uint128) {
-        (uint128 _amount0, uint128 _amount1) = pool.collect(
-            msg.sender,
-            lowerTick,
-            upperTick,
-            type(uint128).max,
-            type(uint128).max
-        );
-        return reversed ? (_amount1, _amount0) : (_amount0, _amount1);
-    }
-
-    function burn(int24 lowerTick, int24 upperTick, uint128 liquidity) external onlyVault returns (uint256, uint256) {
-        _takeFee(lowerTick, upperTick);
-        (uint256 _burn0, uint256 _burn1) = pool.burn(lowerTick, upperTick, liquidity);
-        return reversed ? (_burn1, _burn0) : (_burn0, _burn1);
     }
 
     function burnAndCollect(

--- a/contracts/poolManager/UniswapV3LiquidityPoolManager.sol
+++ b/contracts/poolManager/UniswapV3LiquidityPoolManager.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.16;
 
-import {ILiquidityPoolManager} from "../interfaces/ILiquidityPoolManager.sol";
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 
 import {IUniswapV3Pool} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
@@ -9,14 +8,16 @@ import {IUniswapV3MintCallback} from "@uniswap/v3-core/contracts/interfaces/call
 import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
-//libraries
-import {ErrorsV1} from "../coreV1/ErrorsV1.sol";
-import {TickMath} from "../libs/uniswap/TickMath.sol";
-import {FullMath, LiquidityAmounts} from "../libs/uniswap/LiquidityAmounts.sol";
+import {ILiquidityPoolManager} from "@src/interfaces/ILiquidityPoolManager.sol";
+import {ErrorsV1} from "@src/coreV1/ErrorsV1.sol";
+import {TickMath} from "@src/libs/uniswap/TickMath.sol";
+import {FullMath, LiquidityAmounts} from "@src/libs/uniswap/LiquidityAmounts.sol";
+import {ILiquidityPoolCollectable, PerformanceFee} from "@src/poolManager/libs/PerformanceFee.sol";
 
 contract UniswapV3LiquidityPoolManager is Ownable, ILiquidityPoolManager, IUniswapV3MintCallback {
     using SafeERC20 for IERC20;
     using TickMath for int24;
+    using PerformanceFee for ILiquidityPoolCollectable;
 
     /* ========== Structs ========== */
 
@@ -214,7 +215,14 @@ contract UniswapV3LiquidityPoolManager is Ownable, ILiquidityPoolManager, IUnisw
         int24 upperTick,
         uint128 liquidity
     ) external onlyVault returns (uint256, uint256) {
-        _takeFee(lowerTick, upperTick);
+        PerformanceFee.FeeCollectParams memory _params = PerformanceFee.FeeCollectParams({
+            lowerTick: lowerTick,
+            upperTick: upperTick,
+            perfFeeRecipient: perfFeeRecipient,
+            perfFeeDivisor: perfFeeDivisor
+        });
+        ILiquidityPoolCollectable(address(pool)).takeFee(_params);
+
         uint256 _burn0;
         uint256 _burn1;
         if (liquidity > 0) {
@@ -222,37 +230,6 @@ contract UniswapV3LiquidityPoolManager is Ownable, ILiquidityPoolManager, IUnisw
         }
         pool.collect(msg.sender, lowerTick, upperTick, type(uint128).max, type(uint128).max);
         return reversed ? (_burn1, _burn0) : (_burn0, _burn1);
-    }
-
-    function _takeFee(int24 lowerTick, int24 upperTick) internal {
-        // if no recipient, skip
-        if (perfFeeRecipient == address(0)) return;
-        // if divisor set to zero, skip
-        if (perfFeeDivisor == 0) return;
-
-        // zero burn to update feeGrowth
-        pool.burn(lowerTick, upperTick, 0);
-
-        (uint128 _amount0, uint128 _amount1) = pool.collect(
-            msg.sender,
-            lowerTick,
-            upperTick,
-            type(uint128).max,
-            type(uint128).max
-        );
-
-        (uint128 _a0, uint128 _a1) = reversed ? (_amount1, _amount0) : (_amount0, _amount1);
-
-        IERC20 _token0 = IERC20(pool.token0());
-        IERC20 _token1 = IERC20(pool.token1());
-
-        (uint128 _perfFee0, uint128 _perfFee1) = (_a0 / perfFeeDivisor, _a1 / perfFeeDivisor);
-
-        if (_perfFee0 > 0 && _token0.balanceOf(msg.sender) >= _perfFee0)
-            _token0.safeTransferFrom(msg.sender, perfFeeRecipient, _perfFee0);
-
-        if (_perfFee1 > 0 && _token1.balanceOf(msg.sender) >= _perfFee1)
-            _token1.safeTransferFrom(msg.sender, perfFeeRecipient, _perfFee1);
     }
 
     /* ========== CALLBACK FUNCTIONS ========== */

--- a/contracts/poolManager/libs/PerformanceFee.sol
+++ b/contracts/poolManager/libs/PerformanceFee.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.16;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/**
+ * @title ILiquidityPoolCollectable
+ * @author Orange Finance
+ * @notice Interface for the Liquidity Pool that is compatible with Performance Fee.
+ * We currently assume that the pool is Uniswap V3 Pool or Camelot V3 Pool.
+ */
+interface ILiquidityPoolCollectable {
+    function token0() external view returns (address);
+
+    function token1() external view returns (address);
+
+    function collect(
+        address recipient,
+        int24 tickLower,
+        int24 tickUpper,
+        uint128 amount0Requested,
+        uint128 amount1Requested
+    ) external returns (uint128 amount0, uint128 amount1);
+
+    function burn(int24 tickLower, int24 tickUpper, uint128 amount) external;
+}
+
+/**
+ * @title PerformanceFee
+ * @notice A library that provides functions to collect performance fee from Uniswap V3 Pool or Camelot V3 Pool.
+ */
+library PerformanceFee {
+    using SafeERC20 for IERC20;
+
+    /**
+     * @notice Parameters for collecting performance fee.
+     * @param lowerTick The lower tick of the range to collect fees on.
+     * @param upperTick The upper tick of the range to collect fees on.
+     * @param perfFeeDivisor The divisor to calculate performance fee.
+     * @param perfFeeRecipient The recipient of performance fee.
+     */
+    struct FeeCollectParams {
+        int24 lowerTick;
+        int24 upperTick;
+        uint128 perfFeeDivisor;
+        address perfFeeRecipient;
+    }
+
+    /// @notice Collects performance fee from the pool.
+    function takeFee(ILiquidityPoolCollectable pool, FeeCollectParams memory params) internal {
+        address perfFeeRecipient = params.perfFeeRecipient;
+        uint128 perfFeeDivisor = params.perfFeeDivisor;
+        int24 lowerTick = params.lowerTick;
+        int24 upperTick = params.upperTick;
+
+        // if no recipient, skip
+        if (perfFeeRecipient == address(0)) return;
+        // if divisor set to zero, skip
+        if (perfFeeDivisor == 0) return;
+
+        // zero burn to update feeGrowth
+        pool.burn(lowerTick, upperTick, 0);
+
+        (uint128 _amount0, uint128 _amount1) = pool.collect(
+            msg.sender,
+            lowerTick,
+            upperTick,
+            type(uint128).max,
+            type(uint128).max
+        );
+
+        IERC20 _token0 = IERC20(pool.token0());
+        IERC20 _token1 = IERC20(pool.token1());
+
+        (uint128 _perfFee0, uint128 _perfFee1) = (_amount0 / perfFeeDivisor, _amount1 / perfFeeDivisor);
+
+        if (_perfFee0 > 0 && _token0.balanceOf(msg.sender) >= _perfFee0)
+            _token0.safeTransferFrom(msg.sender, perfFeeRecipient, _perfFee0);
+
+        if (_perfFee1 > 0 && _token1.balanceOf(msg.sender) >= _perfFee1)
+            _token1.safeTransferFrom(msg.sender, perfFeeRecipient, _perfFee1);
+    }
+}

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,3 +1,4 @@
 ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
-
+@src/=contracts/
+@test/=test/

--- a/test/foundry/poolManager/CamelotV3LiquidityPoolManagerTest.t.sol
+++ b/test/foundry/poolManager/CamelotV3LiquidityPoolManagerTest.t.sol
@@ -79,19 +79,21 @@ contract CamelotV3LiquidityPoolManagerTest is BaseTest, IAlgebraSwapCallback {
 
         vm.expectRevert(bytes("ONLY_VAULT"));
         vm.prank(alice);
-        liquidityPool.collect(lowerTick, upperTick);
-
-        vm.expectRevert(bytes("ONLY_VAULT"));
-        vm.prank(alice);
-        liquidityPool.burn(lowerTick, upperTick, 0);
-
-        vm.expectRevert(bytes("ONLY_VAULT"));
-        vm.prank(alice);
         liquidityPool.burnAndCollect(lowerTick, upperTick, 0);
 
         vm.expectRevert(bytes("ONLY_CALLBACK_CALLER"));
         vm.prank(alice);
         liquidityPool.algebraMintCallback(0, 0, bytes(""));
+    }
+
+    function test_onlyOwner_Revert() public {
+        vm.expectRevert(bytes("Ownable: caller is not the owner"));
+        vm.prank(alice);
+        liquidityPool.setPerfFeeRecipient(address(0));
+
+        vm.expectRevert(bytes("Ownable: caller is not the owner"));
+        vm.prank(alice);
+        liquidityPool.setPerfFeeDivisor(0);
     }
 
     function test_constructor_Success() public {
@@ -156,16 +158,93 @@ contract CamelotV3LiquidityPoolManagerTest is BaseTest, IAlgebraSwapCallback {
         uint _balance1 = token1.balanceOf(address(this));
 
         // burn and collect
-        (uint burn0_, uint burn1_) = liquidityPool.burn(lowerTick, upperTick, _liquidity);
+        (uint burn0_, uint burn1_) = liquidityPool.burnAndCollect(lowerTick, upperTick, _liquidity);
         assertEq(_amount0, burn0_);
         assertEq(_amount1, burn1_);
         _consoleBalance();
 
-        (uint collect0, uint collect1) = liquidityPool.collect(lowerTick, upperTick);
-        console2.log(collect0, collect1);
         assertEq(_balance0 + fee0 + burn0_, token0.balanceOf(address(this)));
         assertEq(_balance1 + fee1 + burn1_, token1.balanceOf(address(this)));
         _consoleBalance();
+    }
+
+    function test_allWithPerfFee_Success() public {
+        liquidityPool.setPerfFeeRecipient(david);
+        liquidityPool.setPerfFeeDivisor(20); // 5%
+
+        //compute liquidity
+        uint128 _liquidity = liquidityPool.getLiquidityForAmounts(lowerTick, upperTick, 1 ether, 1000 * 1e6);
+
+        //mint
+        (uint _amount0, uint _amount1) = liquidityPool.mint(lowerTick, upperTick, _liquidity);
+
+        //assertion of mint
+        (uint _amount0_, uint _amount1_) = liquidityPool.getAmountsForLiquidity(lowerTick, upperTick, _liquidity);
+        assertEq(_amount0, _amount0_ + 1);
+        assertEq(_amount1, _amount1_ + 1);
+
+        uint128 _liquidity2 = liquidityPool.getCurrentLiquidity(lowerTick, upperTick);
+        assertEq(_liquidity, _liquidity2);
+
+        //swap
+        multiSwapByCarol();
+
+        //compute current fee and position
+        (uint256 fee0, uint256 fee1) = liquidityPool.getFeesEarned(lowerTick, upperTick);
+        (_amount0, _amount1) = liquidityPool.getAmountsForLiquidity(lowerTick, upperTick, _liquidity);
+        uint _balance0 = token0.balanceOf(address(this));
+        uint _balance1 = token1.balanceOf(address(this));
+
+        // burn and collect
+        (uint burn0_, uint burn1_) = liquidityPool.burnAndCollect(lowerTick, upperTick, _liquidity);
+        assertEq(_amount0, burn0_);
+        assertEq(_amount1, burn1_);
+
+        // 5% of fee
+        (uint _perfFee0, uint _perfFee1) = (fee0 / 20, fee1 / 20);
+
+        assertEq(token0.balanceOf(david), _perfFee0);
+        assertEq(token1.balanceOf(david), _perfFee1);
+        assertEq(token0.balanceOf(address(this)), _balance0 + fee0 - _perfFee0 + burn0_);
+        assertEq(token1.balanceOf(address(this)), _balance1 + fee1 - _perfFee1 + burn1_);
+    }
+
+    function test_allWithZeroFee_Success() public {
+        liquidityPool.setPerfFeeRecipient(david);
+        liquidityPool.setPerfFeeDivisor(0); // no performance fee
+
+        //compute liquidity
+        uint128 _liquidity = liquidityPool.getLiquidityForAmounts(lowerTick, upperTick, 1 ether, 1000 * 1e6);
+
+        //mint
+        (uint _amount0, uint _amount1) = liquidityPool.mint(lowerTick, upperTick, _liquidity);
+
+        //assertion of mint
+        (uint _amount0_, uint _amount1_) = liquidityPool.getAmountsForLiquidity(lowerTick, upperTick, _liquidity);
+        assertEq(_amount0, _amount0_ + 1);
+        assertEq(_amount1, _amount1_ + 1);
+
+        uint128 _liquidity2 = liquidityPool.getCurrentLiquidity(lowerTick, upperTick);
+        assertEq(_liquidity, _liquidity2);
+
+        //swap
+        multiSwapByCarol();
+
+        //compute current fee and position
+        (uint256 fee0, uint256 fee1) = liquidityPool.getFeesEarned(lowerTick, upperTick);
+        (_amount0, _amount1) = liquidityPool.getAmountsForLiquidity(lowerTick, upperTick, _liquidity);
+        uint _balance0 = token0.balanceOf(address(this));
+        uint _balance1 = token1.balanceOf(address(this));
+
+        // burn and collect
+        (uint burn0_, uint burn1_) = liquidityPool.burnAndCollect(lowerTick, upperTick, _liquidity);
+        assertEq(_amount0, burn0_);
+        assertEq(_amount1, burn1_);
+
+        assertEq(token0.balanceOf(david), 0);
+        assertEq(token1.balanceOf(david), 0);
+        assertEq(token0.balanceOf(address(this)), _balance0 + fee0 + burn0_);
+        assertEq(token1.balanceOf(address(this)), _balance1 + fee1 + burn1_);
     }
 
     function test_allReverse_Success() public {
@@ -205,13 +284,10 @@ contract CamelotV3LiquidityPoolManagerTest is BaseTest, IAlgebraSwapCallback {
         uint _balance1 = token0.balanceOf(address(this));
 
         // burn and collect
-        (uint burn0_, uint burn1_) = liquidityPool.burn(lowerTick, upperTick, _liquidity);
+        (uint burn0_, uint burn1_) = liquidityPool.burnAndCollect(lowerTick, upperTick, _liquidity);
         assertEq(_amount0, burn0_);
         assertEq(_amount1, burn1_);
-        // _consoleBalance();
 
-        (uint collect0, uint collect1) = liquidityPool.collect(lowerTick, upperTick);
-        console2.log(collect0, collect1);
         assertEq(_balance0 + fee0 + burn0_, token1.balanceOf(address(this)));
         assertEq(_balance1 + fee1 + burn1_, token0.balanceOf(address(this)));
         // _consoleBalance();

--- a/test/foundry/poolManager/CamelotV3LiquidityPoolManagerTest.t.sol
+++ b/test/foundry/poolManager/CamelotV3LiquidityPoolManagerTest.t.sol
@@ -1,19 +1,18 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.16;
 
-import "../utils/BaseTest.sol";
+import "@test/foundry/utils/BaseTest.sol";
 
-import {CamelotV3LiquidityPoolManager, ILiquidityPoolManager} from "../../../contracts/poolManager/CamelotV3LiquidityPoolManager.sol";
-
-import {IAlgebraPool} from "../../../contracts/vendor/algebra/IAlgebraPool.sol";
-import {IDataStorageOperator} from "../../../contracts/vendor/algebra/IDataStorageOperator.sol";
-import {IAlgebraSwapCallback} from "../../../contracts/vendor/algebra/callback/IAlgebraSwapCallback.sol";
-import "@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
+import {ISwapRouter} from "@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
 import {IERC20, SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import {TickMath} from "../../../contracts/libs/uniswap/TickMath.sol";
-import {OracleLibrary} from "../../../contracts/libs/uniswap/OracleLibrary.sol";
-import {FullMath, LiquidityAmounts} from "../../../contracts/libs/uniswap/LiquidityAmounts.sol";
+
+import {IAlgebraPool} from "@src/vendor/algebra/IAlgebraPool.sol";
+import {IDataStorageOperator} from "@src/vendor/algebra/IDataStorageOperator.sol";
+import {IAlgebraSwapCallback} from "@src/vendor/algebra/callback/IAlgebraSwapCallback.sol";
+
+import {CamelotV3LiquidityPoolManager} from "@src/poolManager/CamelotV3LiquidityPoolManager.sol";
+import {TickMath} from "@src/libs/uniswap/TickMath.sol";
+import {FullMath} from "@src/libs/uniswap/LiquidityAmounts.sol";
 
 contract CamelotV3LiquidityPoolManagerTest is BaseTest, IAlgebraSwapCallback {
     using SafeERC20 for IERC20;

--- a/test/foundry/poolManager/UniswapV3LiquidityPoolManagerTest.t.sol
+++ b/test/foundry/poolManager/UniswapV3LiquidityPoolManagerTest.t.sol
@@ -73,14 +73,6 @@ contract UniswapV3LiquidityPoolManagerTest is BaseTest {
 
         vm.expectRevert(bytes("ONLY_VAULT"));
         vm.prank(alice);
-        liquidityPool.collect(lowerTick, upperTick);
-
-        vm.expectRevert(bytes("ONLY_VAULT"));
-        vm.prank(alice);
-        liquidityPool.burn(lowerTick, upperTick, 0);
-
-        vm.expectRevert(bytes("ONLY_VAULT"));
-        vm.prank(alice);
         liquidityPool.burnAndCollect(lowerTick, upperTick, 0);
 
         vm.expectRevert(bytes("ONLY_CALLBACK_CALLER"));
@@ -160,13 +152,10 @@ contract UniswapV3LiquidityPoolManagerTest is BaseTest {
         uint _balance1 = token1.balanceOf(address(this));
 
         // burn and collect
-        (uint burn0_, uint burn1_) = liquidityPool.burn(lowerTick, upperTick, _liquidity);
+        (uint burn0_, uint burn1_) = liquidityPool.burnAndCollect(lowerTick, upperTick, _liquidity);
         assertEq(_amount0, burn0_);
         assertEq(_amount1, burn1_);
-        // _consoleBalance();
 
-        (uint collect0, uint collect1) = liquidityPool.collect(lowerTick, upperTick);
-        console2.log(collect0, collect1);
         assertEq(_balance0 + fee0 + burn0_, token0.balanceOf(address(this)));
         assertEq(_balance1 + fee1 + burn1_, token1.balanceOf(address(this)));
         // _consoleBalance();
@@ -200,11 +189,9 @@ contract UniswapV3LiquidityPoolManagerTest is BaseTest {
         uint _balance1 = token1.balanceOf(address(this));
 
         // burn and collect
-        (uint burn0_, uint burn1_) = liquidityPool.burn(lowerTick, upperTick, _liquidity);
+        (uint burn0_, uint burn1_) = liquidityPool.burnAndCollect(lowerTick, upperTick, _liquidity);
         assertEq(_amount0, burn0_);
         assertEq(_amount1, burn1_);
-
-        liquidityPool.collect(lowerTick, upperTick);
 
         // 5% of fee
         (uint _perfFee0, uint _perfFee1) = (fee0 / 20, fee1 / 20);
@@ -243,11 +230,9 @@ contract UniswapV3LiquidityPoolManagerTest is BaseTest {
         uint _balance1 = token1.balanceOf(address(this));
 
         // burn and collect
-        (uint burn0_, uint burn1_) = liquidityPool.burn(lowerTick, upperTick, _liquidity);
+        (uint burn0_, uint burn1_) = liquidityPool.burnAndCollect(lowerTick, upperTick, _liquidity);
         assertEq(_amount0, burn0_);
         assertEq(_amount1, burn1_);
-
-        liquidityPool.collect(lowerTick, upperTick);
 
         assertEq(token0.balanceOf(david), 0);
         assertEq(token1.balanceOf(david), 0);
@@ -292,13 +277,11 @@ contract UniswapV3LiquidityPoolManagerTest is BaseTest {
         uint _balance1 = token0.balanceOf(address(this));
 
         // burn and collect
-        (uint burn0_, uint burn1_) = liquidityPool.burn(lowerTick, upperTick, _liquidity);
+        (uint burn0_, uint burn1_) = liquidityPool.burnAndCollect(lowerTick, upperTick, _liquidity);
         assertEq(_amount0, burn0_);
         assertEq(_amount1, burn1_);
         // _consoleBalance();
 
-        (uint collect0, uint collect1) = liquidityPool.collect(lowerTick, upperTick);
-        console2.log(collect0, collect1);
         assertEq(_balance0 + fee0 + burn0_, token1.balanceOf(address(this)));
         assertEq(_balance1 + fee1 + burn1_, token0.balanceOf(address(this)));
         // _consoleBalance();

--- a/test/foundry/poolManager/UniswapV3LiquidityPoolManagerTest.t.sol
+++ b/test/foundry/poolManager/UniswapV3LiquidityPoolManagerTest.t.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.16;
 
-import "../utils/BaseTest.sol";
+import "@test/foundry/utils/BaseTest.sol";
 
-import {UniswapV3LiquidityPoolManager, ILiquidityPoolManager, UniswapV3LiquidityPoolManager} from "../../../contracts/poolManager/UniswapV3LiquidityPoolManager.sol";
+import {IUniswapV3Pool} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
+import {ISwapRouter} from "@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
 
-import "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
-import "@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
 import {IERC20, SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import {TickMath} from "../../../contracts/libs/uniswap/TickMath.sol";
-import {OracleLibrary} from "../../../contracts/libs/uniswap/OracleLibrary.sol";
-import {FullMath, LiquidityAmounts} from "../../../contracts/libs/uniswap/LiquidityAmounts.sol";
+
+import {UniswapV3LiquidityPoolManager} from "@src/poolManager/UniswapV3LiquidityPoolManager.sol";
+import {TickMath} from "@src/libs/uniswap/TickMath.sol";
+import {FullMath} from "@src/libs/uniswap/LiquidityAmounts.sol";
 
 contract UniswapV3LiquidityPoolManagerTest is BaseTest {
     using SafeERC20 for IERC20;


### PR DESCRIPTION
Following the guidelines in WP-I1, I removed unused functions to avoid accidentally collecting burned positions as performance fee targets.

This PR also includes the following changes:

- Moved the performance fee logic to a library for sharing between UniswapV3 and Camelot.
- Removed the check for the `reversed` variable in the `takeFee` function since `token0` and `token1`, obtained from the Uniswap/Camelot pool contract, are already reversed and no value returns to the vault.
