### PR TITLE
Audit: Performance Fee Fix WP-M1, N2

### DIFF
--- a/contracts/poolManager/CamelotV3LiquidityPoolManager.sol
+++ b/contracts/poolManager/CamelotV3LiquidityPoolManager.sol
@@ -235,6 +235,8 @@ contract CamelotV3LiquidityPoolManager is Ownable, ILiquidityPoolManager, IAlgeb
         int24 upperTick,
         uint128 liquidity
     ) external onlyVault returns (uint256, uint256) {
+        if (liquidity == 0) return (0, 0);
+
         PerformanceFee.FeeCollectParams memory _params = PerformanceFee.FeeCollectParams({
             lowerTick: lowerTick,
             upperTick: upperTick,

--- a/contracts/poolManager/UniswapV3LiquidityPoolManager.sol
+++ b/contracts/poolManager/UniswapV3LiquidityPoolManager.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.16;
 
-import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-
 import {IUniswapV3Pool} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 import {IUniswapV3MintCallback} from "@uniswap/v3-core/contracts/interfaces/callback/IUniswapV3MintCallback.sol";
 import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -215,6 +213,8 @@ contract UniswapV3LiquidityPoolManager is Ownable, ILiquidityPoolManager, IUnisw
         int24 upperTick,
         uint128 liquidity
     ) external onlyVault returns (uint256, uint256) {
+        if (liquidity == 0) return (0, 0);
+
         PerformanceFee.FeeCollectParams memory _params = PerformanceFee.FeeCollectParams({
             lowerTick: lowerTick,
             upperTick: upperTick,

--- a/foundry.toml
+++ b/foundry.toml
@@ -21,3 +21,6 @@ solc_version = '0.8.16'
 [profile.default.optimizer_details.yulDetails]
 #optimizerSteps = 'dhfoDgvulfnTUtnIf'
 #stackAllocation = true
+
+[rpc_endpoints]
+arb = "${ARB_URL}"

--- a/test/foundry/poolManager/CamelotV3LiquidityPoolManagerTest.t.sol
+++ b/test/foundry/poolManager/CamelotV3LiquidityPoolManagerTest.t.sol
@@ -40,6 +40,9 @@ contract CamelotV3LiquidityPoolManagerTest is BaseTest, IAlgebraSwapCallback {
     // currentTick = -201279;
 
     function setUp() public virtual {
+        uint256 _forkBlock = 103719100;
+        vm.createSelectFork(vm.rpcUrl("arb"), _forkBlock);
+
         (tokenAddr, , uniswapAddr) = AddressHelper.addresses(block.chainid);
         (, camelotAddr) = AddressHelperV2.addresses(block.chainid);
 
@@ -124,6 +127,16 @@ contract CamelotV3LiquidityPoolManagerTest is BaseTest, IAlgebraSwapCallback {
         liquidityPool.validateTicks(lowerTick, 1);
         vm.expectRevert(bytes("INVALID_TICKS"));
         liquidityPool.validateTicks(upperTick, lowerTick);
+    }
+
+    function test_burnAndCollect_ReturnsZero() public {
+        liquidityPool.setPerfFeeRecipient(david);
+        liquidityPool.setPerfFeeDivisor(20); // 5%
+
+        (uint256 _burned0, uint256 _burned1) = liquidityPool.burnAndCollect(lowerTick, upperTick, 0);
+
+        assertEq(_burned0, 0);
+        assertEq(_burned1, 0);
     }
 
     function test_all_Success() public {

--- a/test/foundry/poolManager/UniswapV3LiquidityPoolManagerTest.t.sol
+++ b/test/foundry/poolManager/UniswapV3LiquidityPoolManagerTest.t.sol
@@ -37,6 +37,9 @@ contract UniswapV3LiquidityPoolManagerTest is BaseTest {
     // currentTick = -204714;
 
     function setUp() public virtual {
+        uint256 _forkBlock = 46334701;
+        vm.createSelectFork(vm.rpcUrl("arb"), _forkBlock);
+
         (tokenAddr, , uniswapAddr) = AddressHelper.addresses(block.chainid);
 
         pool = IUniswapV3Pool(uniswapAddr.wethUsdcPoolAddr500);
@@ -119,6 +122,16 @@ contract UniswapV3LiquidityPoolManagerTest is BaseTest {
         liquidityPool.validateTicks(lowerTick, 1);
         vm.expectRevert(bytes("INVALID_TICKS"));
         liquidityPool.validateTicks(upperTick, lowerTick);
+    }
+
+    function test_burnAndCollect_ReturnsZero() public {
+        liquidityPool.setPerfFeeRecipient(david);
+        liquidityPool.setPerfFeeDivisor(20); // 5%
+
+        (uint256 _burned0, uint256 _burned1) = liquidityPool.burnAndCollect(lowerTick, upperTick, 0);
+
+        assertEq(_burned0, 0);
+        assertEq(_burned1, 0);
     }
 
     function test_all_Success() public {


### PR DESCRIPTION
Following the WP-M1/N2 guidelines, I made the following changes:

- Modified `UniSwapV3 / CamelotLiquidityManager`’s `burnAndCollectFee` to return 0 when liquidity is zero and added test cases.
- Removed unused imports from `UniswapV3LiquidityManager`.

This recommendation has not been included because AlphaVault is no longer in use, I'll remove the related code in another PR.

> Once the above change is implemented, it won't be necessary to wrap _burnAndCollectFees() inside an if (liquidity > 0) {} check:


